### PR TITLE
Fixed youtube-dl download

### DIFF
--- a/docker/jukebox/Dockerfile
+++ b/docker/jukebox/Dockerfile
@@ -18,7 +18,7 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 WORKDIR /var/www/html
 
 # Install youtube-dl
-RUN curl https://yt-dl.org/latest/youtube-dl -o /usr/local/bin/youtube-dl
+RUN curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl
 RUN chmod a+rx /usr/local/bin/youtube-dl
 
 # Create necessary folders


### PR DESCRIPTION
Updated the curl request to youtube-dl to follow 302 redirects and update the download url as per their documentation.

Currently the download fails
