### PR TITLE
Only queue songs in response to a state change

### DIFF
--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -40,6 +40,10 @@ class Song extends Model
         });
 
         static::updated(function (self $song): void {
+            if ($song->isClean('state')) {
+                return;
+            }
+
             if ($song->state === SongState::DOWNLOAD_REQUIRED) {
                 DownloadYouTubeVideo::dispatch($song);
             }


### PR DESCRIPTION
Currently when songs are shuffled (aka everytime a song is added) then all the songs which are currently queued to download are queued again because the change hook is listening for changes to all properties not just the state change